### PR TITLE
Portable way to determine module base address

### DIFF
--- a/compilearmdroid
+++ b/compilearmdroid
@@ -1,0 +1,14 @@
+#!/bin/bash
+#   Compile script for ARM Android.
+# TOOLCHAIN needs to be set to the location of the toolchain,
+#    for example: /opt/ndk/toolchains/arm-linux-androideabi-4.6/prebuilt/linux-x86 
+# SYSROOT must be set to the location of the ndk sys root,
+#    for example: /opt/ndk/platforms/android-14/arch-arm
+GCC=${TOOLCHAIN}/bin/arm-linux-androideabi-gcc
+CFLAGS="-g3 --sysroot=${SYSROOT}"
+rm -f *.so test
+
+${GCC} ${CFLAGS}       -shared -o libtest1.so libtest1.c
+${GCC} ${CFLAGS} -fPIC -shared -o libtest2.so libtest2.c
+
+${GCC} ${CFLAGS} -L$PWD -o test test.c elf_hook.c -ltest1 -ltest2 -ldl

--- a/elf_hook.c
+++ b/elf_hook.c
@@ -310,6 +310,70 @@ static int symbol_by_name(int d, Elf_Shdr *section, char const *name, Elf_Sym **
     return 0;
 }
 //--------------------------------------------------------------------------------------------------
+int get_module_base_address(char const *module_filename, void *handle, void **base)
+{
+    int descriptor;  //file descriptor of shared module
+    Elf_Shdr *dynsym = NULL, *strings_section = NULL;
+    char const *strings = NULL;
+    Elf_Sym *symbols = NULL;
+    size_t i, amount;
+    Elf_Sym *found = NULL;
+
+    *base = NULL;
+
+    descriptor = open(module_filename, O_RDONLY);
+
+    if (descriptor < 0)
+        return errno;
+
+    if (section_by_type(descriptor, SHT_DYNSYM, &dynsym) ||  //get ".dynsym" section
+        section_by_index(descriptor, dynsym->sh_link, &strings_section) ||
+        read_string_table(descriptor, strings_section, &strings) ||
+        read_symbol_table(descriptor, dynsym, &symbols))
+    {
+        free(strings_section);
+        free((void *)strings);
+        free(symbols);
+        free(dynsym);
+        close(descriptor);
+
+        return errno;
+    }
+
+    amount = dynsym->sh_size / sizeof(Elf_Sym);
+
+    /* Trick to get the module base address in a portable way:
+     *   Find the first GLOBAL or WEAK symbol in the symbol table,
+     *   look this up with dlsym, then return the difference as the base address
+     */
+    for (i = 0; i < amount; ++i)
+    {
+        switch(ELF32_ST_BIND(symbols[i].st_info)) {
+        case STB_GLOBAL:
+        case STB_WEAK:
+            found = &symbols[i];
+            break;
+        default: // Not interested in this symbol
+            break;
+        }
+    }
+    if(found != NULL)
+    {
+        const char *name = &strings[found->st_name];
+        void *sym = dlsym(handle, name); 
+        if(sym != NULL)
+            *base = (void*)((size_t)sym - found->st_value);
+    }
+
+    free(strings_section);
+    free((void *)strings);
+    free(symbols);
+    free(dynsym);
+    close(descriptor);
+
+    return *base == NULL;
+}
+//--------------------------------------------------------------------------------------------------
 #ifdef __cplusplus
 extern "C"
 {

--- a/elf_hook.h
+++ b/elf_hook.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#define LIBRARY_ADDRESS_BY_HANDLE(x) ((NULL == x) ? NULL : (void *)*(size_t const *)(x))  //undocumented hack to get shared library's address in memory by its handle
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 
+int get_module_base_address(char const *module_filename, void *handle, void **base);
 void *elf_hook(char const *library_filename, void const *library_address, char const *function_name, void const *substitution_address);
 
 #ifdef __cplusplus

--- a/test.c
+++ b/test.c
@@ -19,17 +19,22 @@ int main()
 {
     void *handle1 = dlopen(LIBTEST1_PATH, RTLD_LAZY);
     void *handle2 = dlopen(LIBTEST2_PATH, RTLD_LAZY);
+    void *base1 = NULL, *base2 = NULL;
     void *original1, *original2;
 
     if (NULL == handle1 || NULL == handle2)
         fprintf(stderr, "Failed to open \"%s\" or \"%s\"!\n", LIBTEST1_PATH, LIBTEST2_PATH);
 
+    if(get_module_base_address(LIBTEST1_PATH, handle1, &base1) ||
+       get_module_base_address(LIBTEST2_PATH, handle2, &base2)) 
+        fprintf(stderr, "Failed to get module base addresses\n");
+
     libtest1();  //calls puts() from libc.so twice
     libtest2();  //calls puts() from libc.so twice
     puts("-----------------------------");
 
-    original1 = elf_hook(LIBTEST1_PATH, LIBRARY_ADDRESS_BY_HANDLE(handle1), "puts", hooked_puts);
-    original2 = elf_hook(LIBTEST2_PATH, LIBRARY_ADDRESS_BY_HANDLE(handle2), "puts", hooked_puts);
+    original1 = elf_hook(LIBTEST1_PATH, base1, "puts", hooked_puts);
+    original2 = elf_hook(LIBTEST2_PATH, base2, "puts", hooked_puts);
 
     if (NULL == original1 || NULL == original2)
         fprintf(stderr, "Redirection failed!\n");
@@ -38,8 +43,8 @@ int main()
     libtest2();  //calls hooked_puts() twice
     puts("-----------------------------");
 
-    original1 = elf_hook(LIBTEST1_PATH, LIBRARY_ADDRESS_BY_HANDLE(handle1), "puts", original1);
-    original2 = elf_hook(LIBTEST2_PATH, LIBRARY_ADDRESS_BY_HANDLE(handle2), "puts", original2);
+    original1 = elf_hook(LIBTEST1_PATH, base1, "puts", original1);
+    original2 = elf_hook(LIBTEST2_PATH, base2, "puts", original2);
 
     if (NULL == original1 || original1 != original2)  //both pointers should contain hooked_puts() address now
         fprintf(stderr, "Restoration failed!\n");


### PR DESCRIPTION
This makes hooking work on Android (with bionic libc). Unlike glibc, bionic returns an opaque pointer that is not equal to the module base address, so the current hack resulted in a segmentation fault.
